### PR TITLE
Create with hooks

### DIFF
--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -8,6 +8,21 @@
 /**
  * Response in JSON for the manifest.
  */
+function islandora_iiif_manifests_view_manifest_json(AbstractObject $object) {
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/datastream');
+
+  if (isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
+    islandora_view_datastream($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
+  }
+  else {
+    islandora_iiif_manifests_create_json_response('403 Forbidden', 'Forbidden');
+  }
+}
+
+/**
+ * Response in JSON for the manifest.
+ */
 function islandora_iiif_manifests_create_manifest_json(AbstractObject $object) {
 
   module_load_include('inc', 'islandora', 'includes/utilities');

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -175,12 +175,7 @@ function islandora_iiif_manifests_detail_tools_block_view() {
   if (arg(1) == 'object' && islandora_is_valid_pid(arg(2))) {
     $obj = islandora_object_load(arg(2));
 
-    $show_menu = FALSE;
-    if (allowedCModel($obj)) {
-      if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, $obj)) {
-        $show_menu = TRUE;
-      }
-    }
+    $show_menu = isset($obj[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
 
     if ($show_menu) {
       $modpath = drupal_get_path('module', 'islandora_iiif_manifests');

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -14,7 +14,7 @@ define('ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID', 'MANIFEST');
 function islandora_iiif_manifests_menu() {
   return array(
     'islandora_iiif_manifests/%islandora_object/manifest' => array(
-      'page callback' => 'islandora_iiif_manifests_create_manifest_json',
+      'page callback' => 'islandora_iiif_manifests_view_manifest_json',
       'page arguments' => array(1),
       'file' => 'includes/manifest.inc',
       'type' => MENU_CALLBACK,

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -6,6 +6,7 @@
 
 define('ISLANDORA_IIIF_MANIFESTS_ISLANDORA_IIIF_MANIFEST_HOOK', 'islandora_get_iiif_manifest');
 define('ISLANDORA_IIIF_MANIFESTS_ISLANDORA_IIIF_MANIFEST_CANVAS_HOOK', 'islandora_get_iiif_manifest_canvas');
+define('ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID', 'MANIFEST');
 
 /**
  * Implements hook_menu().
@@ -225,4 +226,64 @@ function islandora_iiif_manifests_detail_tools_block_view() {
     }
   }
   return $block;
+}
+
+/**
+ * Implements hook_cmodel_pid_check_datastreams_info().
+ */
+function islandora_iiif_manifests_check_datastreams_info($object) {
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
+
+  $generatable = allowedCModel($object);
+  $available = isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
+  $available = $available && ($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]->createdDate >= $object->lastModifiedDate);
+  $available = $available && ($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]->createdDate >= $object['MODS']->createdDate);
+  return array(
+    ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID => array(
+      'available' => $available,
+      'required' => FALSE,
+      'generatable' => $generatable,
+      'remark' => array(
+        'function' => 'islandora_iiif_manifests_check_datastreams_remark',
+      ),
+    ),
+  );
+}
+
+/**
+ * Implements hook_generate_extra_derivatives().
+ */
+function islandora_iiif_manifests_generate_extra_derivatives($object, $what, $options) {
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/manifest');
+
+  $manifestjson = islandora_iiif_manifests_build_manifest($object);
+  if (empty($manifestjson)) {
+    return array(array('success' => FALSE, 'message' => t('Cannot generate IIIF manifest')));
+  }
+  if (isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
+    $object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]->content = $manifestjson;
+
+    return array(array('success' => TRUE, 'message' => t('IIIF manifest updated')));
+  }
+  else {
+    $manifestds = $object->constructDatastream(ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID);
+    $manifestds->label = 'IIIF manifest';
+    $manifestds->mimetype = 'application/json';
+    $manifestds->setContentFromString($manifestjson);
+    $object->ingestDatastream($manifestds);
+
+    return array(array('success' => TRUE, 'message' => t('IIIF manifest created')));
+  }
+}
+
+function islandora_iiif_manifests_check_datastreams_remark($object, $dsid) {
+  if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, $object)) {
+    if (isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
+      return t('Manifest might need update');
+    }
+    return NULL;
+  }
+  else {
+    return t('Object is not accessible for anonymous');
+  }
 }


### PR DESCRIPTION
Create the manifests using hooks provided by islandora_check_datastreams and islandora_batch_modify and store the manifest as a datastream.
When the manifest is requested, it is retrieved from the datastream by standard islandora ways.