### PR TITLE
Check if manifest before generating

### DIFF
--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -239,26 +239,29 @@ function islandora_iiif_manifests_check_datastreams_info($object) {
  * Implements hook_generate_extra_derivatives().
  */
 function islandora_iiif_manifests_generate_extra_derivatives($object, $what, $options) {
-  module_load_include('inc', 'islandora_iiif_manifests', 'includes/manifest');
+  if ($what === ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID) {
+    module_load_include('inc', 'islandora_iiif_manifests', 'includes/manifest');
 
-  $manifestjson = islandora_iiif_manifests_build_manifest($object);
-  if (empty($manifestjson)) {
-    return array(array('success' => FALSE, 'message' => t('Cannot generate IIIF manifest')));
-  }
-  if (isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
-    $object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]->content = $manifestjson;
+    $manifestjson = islandora_iiif_manifests_build_manifest($object);
+    if (empty($manifestjson)) {
+      return array(array('success' => FALSE, 'message' => t('Cannot generate IIIF manifest')));
+    }
+    if (isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
+      $object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]->content = $manifestjson;
 
-    return array(array('success' => TRUE, 'message' => t('IIIF manifest updated')));
-  }
-  else {
-    $manifestds = $object->constructDatastream(ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID);
-    $manifestds->label = 'IIIF manifest';
-    $manifestds->mimetype = 'application/json';
-    $manifestds->setContentFromString($manifestjson);
-    $object->ingestDatastream($manifestds);
+      return array(array('success' => TRUE, 'message' => t('IIIF manifest updated')));
+    }
+    else {
+      $manifestds = $object->constructDatastream(ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID);
+      $manifestds->label = 'IIIF manifest';
+      $manifestds->mimetype = 'application/json';
+      $manifestds->setContentFromString($manifestjson);
+      $object->ingestDatastream($manifestds);
 
-    return array(array('success' => TRUE, 'message' => t('IIIF manifest created')));
+      return array(array('success' => TRUE, 'message' => t('IIIF manifest created')));
+    }
   }
+  return NULL;
 }
 
 function islandora_iiif_manifests_check_datastreams_remark($object, $dsid) {


### PR DESCRIPTION
Before generating the manifest datastream, check that the manifest is really requested.