### PR TITLE
Use configurable IIIF viewer URL

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,12 +31,17 @@ function islandora_iiif_manifests_admin_settings_form($form, &$form_state) {
       '#type' => 'textfield',
       '#title' => t('Manifest Presentation URI'),
       '#default_value' => $get_default_value('islandora_iiif_manifests_presentation_uri', 'http://iiif.io/api/presentation/2/context.json'),
-    )    ,
+    ),
     'islandora_iiif_manifests_domain_uri' => array(
-    '#type' => 'textfield',
-    '#title' => t('Manifest domain URI'),
-    '#default_value' => $get_default_value('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url'] ),
-  )
+      '#type' => 'textfield',
+      '#title' => t('Manifest domain URI'),
+      '#default_value' => $get_default_value('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url'] ),
+    ),
+    'islandora_iiif_manifests_viewer_url' => array(
+      '#type' => 'textfield',
+      '#title' => t('IIIF Viewer URL'),
+      '#default_value' => $get_default_value('islandora_iiif_manifests_viewer_url'),
+    ),
   );
   return system_settings_form($form);
 }

--- a/islandora_iiif_manifests.install
+++ b/islandora_iiif_manifests.install
@@ -9,13 +9,10 @@
 function islandora_iiif_manifests_uninstall() {
 
   $variables = array(
-    'islandora_handle_debug_mode',
-    'islandora_handle_server_admin_password',
-    'islandora_handle_server_admin_username',
-    'islandora_handle_server_prefix',
-    'islandora_handle_server_url',
-    'islandora_handle_handler',
-    'islandora_handle_use_alias',
+    'islandora_iiif_manifests_domain_uri',
+    'islandora_iiif_manifests_image_uri',
+    'islandora_iiif_manifests_presentation_uri',
+    'islandora_iiif_manifests_viewer_url',
   );
   array_walk($variables, 'variable_del');
 

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -187,15 +187,15 @@ function islandora_iiif_manifests_detail_tools_block_view() {
     }
 
     $show_menu = isset($obj[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
-
-    if ($show_menu) {
+    $iiifviewerurl = variable_get('islandora_iiif_manifests_viewer_url');
+    if ($show_menu && $iiifviewerurl) {
       $modpath = drupal_get_path('module', 'islandora_iiif_manifests');
       drupal_add_css($modpath . '/css/iiif_menu.css');
       drupal_add_js($modpath . '/js/iiif_menu.js');
 
       $manifestkey = (count(array_intersect($obj->models, array('islandora:newspaperCModel', 'islandora:collectionCModel'))) > 0) ? "collection" : "manifest";
       $manifest_url = url('/iiif_manifest/' . $obj->id . '/manifest', array('absolute' => TRUE));
-      $mirador_url = url('https://webpresentations-a.universiteitleiden.nl/mirador/', array('external' => TRUE, 'query' => array($manifestkey => $manifest_url)));
+      $mirador_url = url($iiifviewerurl, array('external' => TRUE, 'query' => array($manifestkey => $manifest_url)));
       $text = t('Advanced Viewer');
       $iiifimg = theme('image', array('path' => $modpath . '/images/iiif-logo.svg'));
       $button = "<DIV class=\"iiifbutton\" data-manifest=\"$manifest_url\">$iiifimg<DIV class=\"iiiftext\">$text</DIV></DIV>";


### PR DESCRIPTION
Add an option to configure the URL used for the IIIF viewer. When not configured, do not show the button.
Clean up of variables deleted when uninstalled.