### PR TITLE
Delete temp file when done, suppress warnings

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -276,6 +276,8 @@ function islandora_iiif_manifests_get_image_info($object) {
 
     $imageArray['imageWidth'] = $width;
     $imageArray['imageHeight'] = $height;
+
+    @unlink($temp_file);
   }
   return $imageArray;
 }


### PR DESCRIPTION
Delete the temp file when it is used to find the dimensions of a picture.