### PR TITLE
Show page/child within manifest

### DIFF
--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -180,22 +180,33 @@ function islandora_iiif_manifests_detail_tools_block_view() {
       $parent_info = islandora_compound_object_retrieve_compound_info($obj);
       if (isset($parent_info['parent_pid'])) {
         $parent = islandora_object_load($parent_info['parent_pid']);
-        if (isset($parent[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
-          $obj = $parent;
-        }
       }
+    }
+    if (!isset($parent) && in_array('islandora:pageCModel', $obj->models)) {
+      $parents = islandora_get_parents_from_rels_ext($obj);
+      $parent = array_pop($parents);
     }
 
     $show_menu = isset($obj[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $obj[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
+    $show_menu = $show_menu || isset($parent[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $parent[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]);
     $iiifviewerurl = variable_get('islandora_iiif_manifests_viewer_url');
     if ($show_menu && $iiifviewerurl) {
       $modpath = drupal_get_path('module', 'islandora_iiif_manifests');
       drupal_add_css($modpath . '/css/iiif_menu.css');
       drupal_add_js($modpath . '/js/iiif_menu.js');
 
-      $manifestkey = (count(array_intersect($obj->models, array('islandora:newspaperCModel', 'islandora:collectionCModel'))) > 0) ? "collection" : "manifest";
-      $manifest_url = url('/iiif_manifest/' . $obj->id . '/manifest', array('absolute' => TRUE));
-      $mirador_url = url($iiifviewerurl, array('external' => TRUE, 'query' => array($manifestkey => $manifest_url)));
+      if (isset($parent[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $parent[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
+        $manifestkey = (count(array_intersect($parent->models, array('islandora:newspaperCModel', 'islandora:collectionCModel'))) > 0) ? "collection" : "manifest";
+        $manifest_url = url('/iiif_manifest/' . $parent->id . '/manifest', array('absolute' => TRUE));
+        $canvas_id = url('/iiif_manifest/' . $obj->id . '/canvas/default', array('absolute' => TRUE));
+        $canvas_id = urldecode($canvas_id); // Prevent double encoding of canvas id.
+        $mirador_url = url($iiifviewerurl, array('external' => TRUE, 'query' => array($manifestkey => $manifest_url, 'canvasID' => $canvas_id)));
+      }
+      else {
+        $manifestkey = (count(array_intersect($obj->models, array('islandora:newspaperCModel', 'islandora:collectionCModel'))) > 0) ? "collection" : "manifest";
+        $manifest_url = url('/iiif_manifest/' . $obj->id . '/manifest', array('absolute' => TRUE));
+        $mirador_url = url($iiifviewerurl, array('external' => TRUE, 'query' => array($manifestkey => $manifest_url)));
+      }
       $text = t('Advanced Viewer');
       $iiifimg = theme('image', array('path' => $modpath . '/images/iiif-logo.svg'));
       $button = "<DIV class=\"iiifbutton\" data-manifest=\"$manifest_url\">$iiifimg<DIV class=\"iiiftext\">$text</DIV></DIV>";


### PR DESCRIPTION
On a page of a book/issue or a child of a compound, add the canvas id
of this page/child to the IIIF viewer url and use the manifest of the
parent for the manifest id.