### PR TITLE
Force a date (if it is only a year) into a string instead of a number

### DIFF
--- a/xsl/mods2manifest.xsl
+++ b/xsl/mods2manifest.xsl
@@ -30,6 +30,7 @@
   <xsl:template match="/mods:mods/mods:originInfo[not(@eventType)]/mods:dateIssued[1]">
     <xsl:call-template name="metadata">
       <xsl:with-param name="label">Date issued</xsl:with-param>
+      <xsl:with-param name="type">date</xsl:with-param>
       <xsl:with-param name="firstvalue" select="."/>
     </xsl:call-template>
   </xsl:template>
@@ -221,6 +222,7 @@
   <xsl:template match="/mods:mods/mods:originInfo[@eventType='publication'][1]/mods:dateIssued[1]">
     <xsl:call-template name="metadata">
       <xsl:with-param name="label">Publication date</xsl:with-param>
+      <xsl:with-param name="type">date</xsl:with-param>
       <xsl:with-param name="firstvalue" select="."/>
       <xsl:with-param name="values" select="../../mods:originInfo[@eventType='publication']/mods:dateIssued"/>
     </xsl:call-template>
@@ -354,8 +356,11 @@
           <xsl:value-of select="concat(' (', normalize-space($value/mods:namePart[@type = 'date']), ')')"/>
         </xsl:if>
       </xsl:when>
+      <xsl:when test="$type = 'date'">
+        <xsl:value-of select="concat($value, '&#160;')"/>
+      </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="normalize-space($value/text())"/>
+        <xsl:value-of select="normalize-space($value)"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
When generating the manifest, the metadata is transformed as XML and
then encoded as JSON. Because dates (as in a single year) looks like
a number and we use JSON_NUMERIC_CHECK with json_encode (because the
width and height of the image should be numbers), they will be encoded
as a number. To prevent this from happening, we append a non-breaking-
space to the date.