### PR TITLE
Improve support of image annotations

### DIFF
--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -64,6 +64,8 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
+  
+  // Check if canvas is available
   if(!empty($output)){
     $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
   }else{

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -61,7 +61,6 @@ function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $
  */
 function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   
-  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
   $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
@@ -75,8 +74,6 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
  * @return void
  */
 function islandora_iiif_manifests_create_annotation_json(AbstractObject $object) {
-  
-  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
   $annotation = $output['images'][0];
@@ -111,7 +108,7 @@ function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
  */
 function islandora_iiif_manifests_build_canvas($object) {
   
-  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = array();
   

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -61,7 +61,7 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
-  
+  $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
   islandora_iiif_manifests_create_json_response('200 OK', $output);
 }
 

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -9,6 +9,7 @@
  * Response in JSON for the manifest.
  * Creates collection manifests dynamically if no statict manifest is present
  * Creates newspaper volumes manifest dynamically based on the selected part in the URL
+ * @return void
  */
 function islandora_iiif_manifests_view_manifest_json(AbstractObject $object, $part = NULL) {
   module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
@@ -43,6 +44,7 @@ function islandora_iiif_manifests_view_manifest_json(AbstractObject $object, $pa
 
 /**
  * Response in JSON for the manifest.
+ * @return void
  */
 function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $part = NULL) {
   
@@ -55,6 +57,7 @@ function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $
 
 /**
  * Response in JSON for the canvas.
+ * @return void
  */
 function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   
@@ -82,7 +85,8 @@ function islandora_iiif_manifests_create_annotation_json(AbstractObject $object)
 }
 
 /**
- * Build manifest array.
+ * Build Manifest JSON representation using appropriate hooks for the object's model(s).
+ * @return string JSON-encoded string
  */
 function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
   
@@ -102,7 +106,8 @@ function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
 }
 
 /**
- * Build canvas array.
+ * Build Canvas JSON representation using appropriate hooks for the object's model(s).
+ * @return string JSON-encoded string
  */
 function islandora_iiif_manifests_build_canvas($object) {
   

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -61,6 +61,7 @@ function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $
  */
 function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   
+  module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
   $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
@@ -74,6 +75,8 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
  * @return void
  */
 function islandora_iiif_manifests_create_annotation_json(AbstractObject $object) {
+  
+  module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
   $annotation = $output['images'][0];

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -64,7 +64,16 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
-  $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  if(!empty($output)){
+    $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  }else{
+    $output = array(
+      "data" => '{"error": "No canvas available"}',
+      "status" => "404 Not Found"
+    );
+  }
+  
+  
   islandora_iiif_manifests_create_json_response('200 OK', $output);
 }
 
@@ -79,8 +88,19 @@ function islandora_iiif_manifests_create_annotation_json(AbstractObject $object)
   module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
-  $annotation = $output['images'][0];
-  $annotation['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  
+  // Check if an image is available
+  if (isset($output['images'][0])) {
+    $annotation = $output['images'][0];
+    $annotation['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  }
+  else {
+    $annotation = array(
+      "data" => '{"error": "No manifest available"}',
+      "status" => "404 Not Found"
+    );
+  }
+  
   islandora_iiif_manifests_create_json_response('200 OK', $annotation);
 }
 

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -48,7 +48,7 @@ function islandora_iiif_manifests_view_manifest_json(AbstractObject $object, $pa
  */
 function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $part = NULL) {
   
-  module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_manifest($object, $part);
   
@@ -61,7 +61,7 @@ function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $
  */
 function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
   
-  module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_canvas($object);
   $output['@context'] = 'http://iiif.io/api/presentation/2/context.json';

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -81,7 +81,6 @@ function islandora_iiif_manifests_create_annotation_json(AbstractObject $object)
   $output = islandora_iiif_manifests_build_canvas($object);
   $annotation = $output['images'][0];
   $annotation['@context'] = 'http://iiif.io/api/presentation/2/context.json';
-  
   islandora_iiif_manifests_create_json_response('200 OK', $annotation);
 }
 
@@ -108,11 +107,11 @@ function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
 
 /**
  * Build Canvas JSON representation using appropriate hooks for the object's model(s).
- * @return string JSON-encoded string
+ * @return array
  */
 function islandora_iiif_manifests_build_canvas($object) {
   
-  module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
   
   $output = array();
   
@@ -129,5 +128,5 @@ function islandora_iiif_manifests_build_canvas($object) {
     }
   }
   
-  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
+  return $output;
 }

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -27,13 +27,13 @@ function islandora_iiif_manifests_view_manifest_json(AbstractObject $object, $pa
   else {
     if (!isset($object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
       $response = array(
-        "data" => "No manifest found",
-        "status" => "400 Bad request"
+        "data" => '{"error": "No manifest available"}',
+        "status" => "404 Not Found"
       );
     }
     elseif (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[ISLANDORA_IIIF_MANIFESTS_DATASTREAM_ID])) {
       $response = array(
-        "data" => "Forbidden",
+        "data" => '{"error": "Access to this resource was denied"}',
         "status" => "403 Forbidden"
       );
     }

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -48,7 +48,7 @@ function islandora_iiif_manifests_view_manifest_json(AbstractObject $object, $pa
  */
 function islandora_iiif_manifests_create_manifest_json(AbstractObject $object, $part = NULL) {
   
-  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/utilities');
   
   $output = islandora_iiif_manifests_build_manifest($object, $part);
   
@@ -81,12 +81,13 @@ function islandora_iiif_manifests_create_annotation_json(AbstractObject $object)
   $output = islandora_iiif_manifests_build_canvas($object);
   $annotation = $output['images'][0];
   $annotation['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  
   islandora_iiif_manifests_create_json_response('200 OK', $annotation);
 }
 
 /**
  * Build Manifest JSON representation using appropriate hooks for the object's model(s).
- * @return string JSON-encoded string
+ * @return array
  */
 function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
   
@@ -102,7 +103,7 @@ function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
     }
   }
   
-  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
+  return $output;
 }
 
 /**

--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -66,6 +66,22 @@ function islandora_iiif_manifests_create_canvas_json(AbstractObject $object) {
 }
 
 /**
+ * Send a JSON-encoded response for the image-painting annotation.
+ * There should be exactly one such annotation in our Canvas, allowing us
+ * to build the Canvas and taking the image annotation from it.
+ * @return void
+ */
+function islandora_iiif_manifests_create_annotation_json(AbstractObject $object) {
+  
+  module_load_include('inc', 'islandora_iiif_manifests', 'includes/utilities');
+  
+  $output = islandora_iiif_manifests_build_canvas($object);
+  $annotation = $output['images'][0];
+  $annotation['@context'] = 'http://iiif.io/api/presentation/2/context.json';
+  islandora_iiif_manifests_create_json_response('200 OK', $annotation);
+}
+
+/**
  * Build manifest array.
  */
 function islandora_iiif_manifests_build_manifest($object, $part = NULL) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -6,6 +6,7 @@
 
 /**
  * Build the manifest container.
+ * @return array Manifest as an array
  */
 function islandora_iiif_manifests_create_manifest($object) {
   
@@ -53,6 +54,7 @@ function islandora_iiif_manifests_create_manifest($object) {
 /**
  * Returns the appropriate manifest type for the compound.
  * If the compound only consists out of basic and large image, display the compound as a manifest.
+ * @return string
  */
 function islandora_iiif_manifests_compound_manifest_type($object) {
   
@@ -75,6 +77,7 @@ function islandora_iiif_manifests_compound_manifest_type($object) {
 
 /**
  * Build the default canvas object
+ * @return array Array representation of a Canvas
  */
 function islandora_iiif_manifests_createDefaultCanvas($canvas_object) {
   
@@ -118,6 +121,7 @@ function islandora_iiif_manifests_createDefaultCanvas($canvas_object) {
 
 /**
  * Build the page specific canvas object
+ * @return array Array representation of a Canvas
  */
 function islandora_iiif_manifests_get_object_canvas($object) {
   
@@ -222,7 +226,10 @@ function islandora_iiif_manifests_get_newspaper_member_collection($issue) {
   return $volume_issues;
 }
 
-
+/**
+ * Determines if a Manifest can be created for the object's CModel(s)
+ * @return bool
+ */
 function islandora_iiif_manifests_allowed_cmodel($object) {
   
   $cmodels = array('islandora:sp_basic_image', 'islandora:sp_large_image_cmodel', 'islandora:bookCModel', 'islandora:newspaperCModel', 'islandora:collectionCModel', 'islandora:newspaperIssueCModel', 'islandora:compoundCModel');
@@ -234,6 +241,10 @@ function islandora_iiif_manifests_allowed_cmodel($object) {
   return FALSE;
 }
 
+/**
+ * Determines if a Canvas can be created for the object's CModel(s)
+ * @return bool
+ */
 function islandora_iiif_manifests_allowed_canvas_cmodel($object) {
   
   $cmodels = array('islandora:sp_basic_image', 'islandora:sp_large_image_cmodel', 'islandora:pageCModel', 'islandora:newspaperIssueCModel');
@@ -247,6 +258,7 @@ function islandora_iiif_manifests_allowed_canvas_cmodel($object) {
 
 /**
  * Convert numeric label to a string
+ * @return string
  */
 function islandora_iiif_manifests_convert_label($object) {
   
@@ -293,7 +305,8 @@ function islandora_iiif_manifests_add_issued_date($object, $metadata) {
 }
 
 /**
- * Retrieve object metadata.
+ * Retrieve object metadata from MODS.
+ * @return array
  */
 function islandora_iiif_manifests_get_metadata($object) {
   
@@ -317,7 +330,8 @@ function islandora_iiif_manifests_get_metadata($object) {
 }
 
 /**
- * Retrieve the image width and height
+ * Retrieve the image width and height, and URIs
+ * @return array Array of (technical) image information
  */
 function islandora_iiif_manifests_get_image_info($object) {
   
@@ -463,6 +477,7 @@ function islandora_iiif_manifests_xml_to_array($root) {
 
 /**
  * Helper function to write out a JSON response.
+ * @return void
  */
 function islandora_iiif_manifests_create_json_response($status, $data = NULL) {
   drupal_add_http_header('Status', $status);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -361,7 +361,7 @@ function islandora_iiif_manifests_get_image_info($object) {
   ));
   
   $image_array['thumbnail_uri'] = $islandora_iiif_manifest_image_uri . "/full/80,/0/default.jpg";
-  $image_array['resource_uri'] = $islandora_iiif_manifest_image_uri . "/full/pct:50/0/default.jpg";
+  $image_array['resource_uri'] = $islandora_iiif_manifest_image_uri . "/full/full/0/default.jpg";
   $image_array['service_uri'] = $islandora_iiif_manifest_image_uri;
   $image_array['id_uri'] = $id_uri;
   

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -98,7 +98,7 @@ function islandora_iiif_manifests_createDefaultCanvas($canvas_object) {
         '@type' => 'oa:Annotation',
         'motivation' => 'sc:painting',
         'resource' => array(
-          '@id' => $canvas_object['resource_uri'],
+          '@id' => $canvas_object['id_uri'],
           '@type' => 'dctypes:Image',
           'height' => $canvas_object['imageHeight'],
           'width' => $canvas_object['imageWidth'],
@@ -136,6 +136,7 @@ function islandora_iiif_manifests_get_object_canvas($object) {
   $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
   $canvas_object['resource_uri'] = $image_info['resource_uri'];
   $canvas_object['service_uri'] = $image_info['service_uri'];
+  $canvas_object['id_uri'] = $image_info['id_uri'];
   $canvas_object['imageWidth'] = $image_info['imageWidth'];
   $canvas_object['imageHeight'] = $image_info['imageHeight'];
   
@@ -340,7 +341,7 @@ function islandora_iiif_manifests_get_image_info($object) {
     )
   );
   
-  $id_uri = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/annotation/{$object->id}", array(
+  $id_uri = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/annotation/{$object->label}", array(
     'absolute' => TRUE,
     'language' => (object)array('language' => FALSE),
   ));

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -484,7 +484,7 @@ function islandora_iiif_manifests_create_json_response($status, $data = NULL) {
   drupal_add_http_header('Set-Cookie: cross-site-cookie=bar; SameSite=None; Secure', FALSE);
   
   if ($data !== NULL) {
-    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
+    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
   }
   exit();
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -342,9 +342,9 @@ function islandora_iiif_manifests_get_image_info($object) {
   $handle = $handler->getFullHandle($object);
   
   $encoded_handle = urlencode('hdl:' . $handle);
-  $handle_pieces = explode("/",$handle);
+  $handle_pieces = explode("/", $handle);
   
-  $new_handle = "hdl:".$handle_pieces[0]."%252F".$handle_pieces[1];
+  $new_handle = "hdl:" . $handle_pieces[0] . "%252F" . $handle_pieces[1];
   
   $image_array = array();
   
@@ -480,13 +480,15 @@ function islandora_iiif_manifests_xml_to_array($root) {
  * @return void
  */
 function islandora_iiif_manifests_create_json_response($status, $data = NULL) {
+  
   drupal_add_http_header('Status', $status);
   drupal_add_http_header('Content-Type', 'application/json; charset=utf-8');
   drupal_add_http_header('access-control-allow-origin', '*');
   drupal_add_http_header('Set-Cookie: same-site-cookie=foo; SameSite=Lax', FALSE);
   drupal_add_http_header('Set-Cookie: cross-site-cookie=bar; SameSite=None; Secure', FALSE);
+  
   if ($data !== NULL) {
-    echo $data;
+    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
   }
   exit();
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -145,7 +145,7 @@ function islandora_iiif_manifests_get_object_canvas($object) {
     $canvas_object['label'] = $label;
     $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
     $canvas_object['resource_uri'] = $image_info['resource_uri'];
-    $canvas_object['service_uri'] = $image_info['service_uri'];
+    $canvas_object['service_uri'] = $image_info['id_uri'];
     $canvas_object['imageWidth'] = intval($image_info['imageWidth']);
     $canvas_object['imageHeight'] = intval($image_info['imageHeight']);
   

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -127,25 +127,30 @@ function islandora_iiif_manifests_get_object_canvas($object) {
   
   $image_info = islandora_iiif_manifests_get_image_info($object);
   
-  $id = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/canvas/default", array(
-    'absolute' => TRUE,
-    'language' => (object)array('language' => FALSE),
-  ));
-  
-  $label = islandora_iiif_manifests_convert_label($object);
-  
   $canvas_object = array();
-  $canvas_object['id'] = $id;
-  $canvas_object['label'] = $label;
-  $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
-  $canvas_object['resource_uri'] = $image_info['resource_uri'];
-  $canvas_object['service_uri'] = $image_info['service_uri'];
-  $canvas_object['id_uri'] = $image_info['id_uri'];
-  $canvas_object['imageWidth'] = $image_info['imageWidth'];
-  $canvas_object['imageHeight'] = $image_info['imageHeight'];
   
-  $canvas = islandora_iiif_manifests_createDefaultCanvas($canvas_object);
+  // If imageWidth is not set, then the image file is incorrect. Return an empty canvas array
+  if(!isset($image_info['imageWidth'])){
   
+    $id = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/canvas/default", array(
+      'absolute' => TRUE,
+      'language' => (object)array('language' => FALSE),
+    ));
+  
+  
+    $label = islandora_iiif_manifests_convert_label($object);
+    $canvas_object['id'] = $id;
+    $canvas_object['label'] = $label;
+    $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
+    $canvas_object['resource_uri'] = $image_info['resource_uri'];
+    $canvas_object['service_uri'] = $image_info['service_uri'];
+    $canvas_object['id_uri'] = $image_info['id_uri'];
+    $canvas_object['imageWidth'] = $image_info['imageWidth'];
+    $canvas_object['imageHeight'] = $image_info['imageHeight'];
+  
+    $canvas = islandora_iiif_manifests_createDefaultCanvas($canvas_object);
+  }
+ 
   return $canvas;
 }
 
@@ -341,7 +346,6 @@ function islandora_iiif_manifests_get_image_info($object) {
   $handler = new $handler_class($object);
   $handle = $handler->getFullHandle($object);
   
-  $encoded_handle = urlencode('hdl:' . $handle);
   $handle_pieces = explode("/", $handle);
   
   $new_handle = "hdl:" . $handle_pieces[0] . "%252F" . $handle_pieces[1];

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -341,7 +341,7 @@ function islandora_iiif_manifests_get_image_info($object) {
     )
   );
   
-  $id_uri = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/annotation/{$object->label}", array(
+  $id_uri = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/annotation/image", array(
     'absolute' => TRUE,
     'language' => (object)array('language' => FALSE),
   ));

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -94,11 +94,11 @@ function islandora_iiif_manifests_createDefaultCanvas($canvas_object) {
     ),
     'images' => array(
       array(
-        '@id' => $canvas_object['service_uri'],
+        '@id' => $canvas_object['id_uri'],
         '@type' => 'oa:Annotation',
         'motivation' => 'sc:painting',
         'resource' => array(
-          '@id' => $canvas_object['id_uri'],
+          '@id' => $canvas_object['resource_uri'],
           '@type' => 'dctypes:Image',
           'height' => $canvas_object['imageHeight'],
           'width' => $canvas_object['imageWidth'],

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -127,30 +127,31 @@ function islandora_iiif_manifests_get_object_canvas($object) {
   
   $image_info = islandora_iiif_manifests_get_image_info($object);
   
-  $canvas_object = array();
+ 
+  $canvas = array();
   
   // If imageWidth is not set, then the image file is incorrect. Return an empty canvas array
-  if(!isset($image_info['imageWidth'])){
+  if(!isset($image_info['imageWidth'])) {
   
     $id = url(variable_get('islandora_iiif_manifests_domain_uri', $GLOBALS['base_url']) . "/iiif_manifest/{$object->id}/canvas/default", array(
       'absolute' => TRUE,
       'language' => (object)array('language' => FALSE),
     ));
   
-  
     $label = islandora_iiif_manifests_convert_label($object);
+  
+    $canvas_object = array();
     $canvas_object['id'] = $id;
     $canvas_object['label'] = $label;
     $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
     $canvas_object['resource_uri'] = $image_info['resource_uri'];
     $canvas_object['service_uri'] = $image_info['service_uri'];
-    $canvas_object['id_uri'] = $image_info['id_uri'];
-    $canvas_object['imageWidth'] = $image_info['imageWidth'];
-    $canvas_object['imageHeight'] = $image_info['imageHeight'];
+    $canvas_object['imageWidth'] = intval($image_info['imageWidth']);
+    $canvas_object['imageHeight'] = intval($image_info['imageHeight']);
   
     $canvas = islandora_iiif_manifests_createDefaultCanvas($canvas_object);
   }
- 
+  
   return $canvas;
 }
 

--- a/islandora_iiif_manifests.info
+++ b/islandora_iiif_manifests.info
@@ -5,7 +5,4 @@ dependencies[] = islandora
 dependencies[] = islandora_basic_collection
 dependencies[] = islandora_solr
 dependencies[] = islandora_solr_metadata
-dependencies[] = islandora_handle
-dependencies[] = islandora_paged_content
-dependencies[] = islandora_newspaper
 core = 7.x

--- a/islandora_iiif_manifests.info
+++ b/islandora_iiif_manifests.info
@@ -5,4 +5,7 @@ dependencies[] = islandora
 dependencies[] = islandora_basic_collection
 dependencies[] = islandora_solr
 dependencies[] = islandora_solr_metadata
+dependencies[] = islandora_handle
+dependencies[] = islandora_paged_content
+dependencies[] = islandora_newspaper
 core = 7.x

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -33,7 +33,7 @@ function islandora_iiif_manifests_menu() {
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
     ),
-    'iiif_manifest/%islandora_object/canvas' => array(
+    'iiif_manifest/%islandora_object/canvas/default' => array(
       'page callback' => 'islandora_iiif_manifests_create_canvas_json',
       'page arguments' => array(1),
       'file' => 'includes/manifest.inc',

--- a/islandora_iiif_manifests.module
+++ b/islandora_iiif_manifests.module
@@ -40,6 +40,13 @@ function islandora_iiif_manifests_menu() {
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
     ),
+    'iiif_manifest/%islandora_object/annotation/image' => array(
+      'page callback' => 'islandora_iiif_manifests_create_annotation_json',
+      'page arguments' => array(1),
+      'file' => 'includes/manifest.inc',
+      'type' => MENU_CALLBACK,
+      'access callback' => TRUE,
+    ),
     'admin/islandora/tools/iiif_manifests_admin' => array(
       'title' => 'IIIF manifest module configuration',
       'description' => 'Configure the IIIF Module.',


### PR DESCRIPTION
See the discussion at #27 for context. This PR:

- fixes the URIs for the `Annotation` and the `resource` (main open issue in #27)
- adds an endpoint for retrieving the (single) image-painting annotation using its URI
- adjust the endpoint for retrieving Canvas representations
- uses full-size Image API URIs so that image dimensions match the response and less processing is need for resizing on the fly 
- adds the IIIF Presentation API 2.1 `@context` to Canvas and Annotation responses
- adds and updates `@return` doc tags and descriptions to several functions
- adds module dependencies that were missing
- fixes `module_load_include` calls that used the wrong module