### PR TITLE
Remove numeric check

### DIFF
--- a/includes/manifest.inc
+++ b/includes/manifest.inc
@@ -82,7 +82,7 @@ function islandora_iiif_manifests_build_manifest($object, $part = NULL) {
     }
   }
   
-  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
+  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 }
 
 /**
@@ -107,5 +107,5 @@ function islandora_iiif_manifests_build_canvas($object) {
     }
   }
   
-  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK);
+  return json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 }

--- a/includes/models/newspaper.inc
+++ b/includes/models/newspaper.inc
@@ -55,11 +55,7 @@ function islandora_iiif_manifest_get_newspaper_manifest($object) {
         'absolute' => TRUE,
         'language' => (object)array('language' => FALSE),
       )));
-      
-      if (is_numeric($part_label)) {
-        $part_label = "'" . $part_label . "'";
-      }
-      
+
       // Create newspaper collection
       $newspaper_collection = array(
         "@id" => $manifest_uri,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -309,6 +309,15 @@ function islandora_iiif_manifests_get_metadata($object) {
     $processor->importStylesheet($xsl);
     $manifest = $processor->transformToDoc($mods);
     $metadata = islandora_iiif_manifests_xml_to_array($manifest);
+  
+    $i = 0;
+    foreach ($metadata['manifest']['metadata'] as $metadata_part) {
+  
+      if (is_numeric($metadata_part['value'])) {
+        $metadata['manifest']['metadata'][$i]['value'] = "'" . $metadata_part['value'] . "'";
+      }
+      $i++;
+    }
     
   }
   

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -155,10 +155,6 @@ function islandora_iiif_manifests_get_object_collection($solrobj) {
   
   $label = $solrobj['object_label'];
   
-  if (is_numeric($label)) {
-    $label = "'" . $label . "'";
-  }
-  
   $collection_member = array(
     "@id" => $manifest_uri,
     "@type" => $manifest_type,
@@ -249,12 +245,7 @@ function islandora_iiif_manifests_allowed_canvas_cmodel($object) {
  */
 function islandora_iiif_manifests_convert_label($object) {
   
-  if (is_numeric($object->label)) {
-    $label = "'" . $object->label . "'";
-  }
-  else {
-    $label = $object->label;
-  }
+  $label = $object->label;
   
   // Check if cmodels is a newspaper issue.
   if (count(array_intersect($object->models, array('islandora:newspaperIssueCModel'))) > 0) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -136,8 +136,8 @@ function islandora_iiif_manifests_get_object_canvas($object) {
   $canvas_object['thumbnail_uri'] = $image_info['thumbnail_uri'];
   $canvas_object['resource_uri'] = $image_info['resource_uri'];
   $canvas_object['service_uri'] = $image_info['service_uri'];
-  $canvas_object['imageWidth'] = $image_info['imageWidth'];
-  $canvas_object['imageHeight'] = $image_info['imageHeight'];
+  $canvas_object['imageWidth'] = intval($image_info['imageWidth']);
+  $canvas_object['imageHeight'] = intval($image_info['imageHeight']);
   
   $canvas = islandora_iiif_manifests_createDefaultCanvas($canvas_object);
   
@@ -309,15 +309,6 @@ function islandora_iiif_manifests_get_metadata($object) {
     $processor->importStylesheet($xsl);
     $manifest = $processor->transformToDoc($mods);
     $metadata = islandora_iiif_manifests_xml_to_array($manifest);
-  
-    $i = 0;
-    foreach ($metadata['manifest']['metadata'] as $metadata_part) {
-  
-      if (is_numeric($metadata_part['value'])) {
-        $metadata['manifest']['metadata'][$i]['value'] = "'" . $metadata_part['value'] . "'";
-      }
-      $i++;
-    }
     
   }
   


### PR DESCRIPTION
Some numbers in the metadata are supposed to be displayed as strings.  JSON_NUMERIC_CHECK converted numbers that were supposed to be strings to integer. Removed this option in the json_encode